### PR TITLE
Fixed script folder link inside readme in Fusion Folder

### DIFF
--- a/Fusion/README.md
+++ b/Fusion/README.md
@@ -90,7 +90,7 @@ where d is the value of pixel at (x,y) in confidence map obtained from Oak-D Pro
 ### Demo
 **To run Fusion on Oak-D Pro , follow the given steps :**
 
-1. Generate blob file for any one model by following steps given in [Convertor](../Assets/Images/Converter) Readme.
+1. Generate blob file for any one model by following steps given in [scripts](../scripts) Readme.
 
 
 1. 


### PR DESCRIPTION
The README inside Fusion was linking to Convertor Folder which has been renamed to scripts . This PR fixes it .